### PR TITLE
OJ-2342: IaC synthetic canaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # ipv-cri-check-smoke-tests
 
 HMRC Check Credential Issuer API Smoke Tests
+
+## Running Canaries Locally
+
+### Using AWS
+To run the canaries locally you need to do the following steps:
+1. Deploy the stack to AWS
+2. Grab the AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN from https://uk-digital-identity.awsapps.com/start/
+3. In the DockerFile on line 2 add the following:
+    ```
+    env AWS_ACCESS_KEY_ID="<value from aws>"
+    env AWS_SECRET_ACCESS_KEY="<value from aws>"
+    env AWS_SESSION_TOKEN="<value from aws>"
+    env AWS_REGION="eu-west-2"
+    ```
+4. Run `docker-compose up --build`
+
+This will then invoke the Canary-Invoker Lambda from the `ipv-cri-check-hmrc-smoke-tests` stack. If you want to use your
+own stack then update the `run-tests.sh` to point to your stack.

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1,6 +1,7 @@
 AWSTemplateFormatVersion: "2010-09-09"
-Transform: [AWS::LanguageExtensions, AWS::Serverless-2016-10-31]
+Transform: [ AWS::LanguageExtensions, AWS::Serverless-2016-10-31 ]
 Description: "Digital Identity IPV CRI Ipv-Cri-Check-Hmrc-Smoke-Tests API"
+
 Parameters:
   Environment:
     Type: String
@@ -12,20 +13,105 @@ Parameters:
     Default: ""
 
 Conditions:
-  EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
-  IsDevEnvironment: !Equals [!Ref Environment, dev]
-  IsLocalDevEnvironment: !Equals [!Ref Environment, localdev]
+  EnforceCodeSigning: !Not [ !Equals [ !Ref CodeSigningConfigArn, "" ] ]
+  IsDevEnvironment: !Equals [ !Ref Environment, dev ]
+  IsLocalDevEnvironment: !Equals [ !Ref Environment, localdev ]
   IsDevLikeEnvironment:
-    !Or [!Condition IsLocalDevEnvironment, !Condition IsDevEnvironment]
+    !Or [ !Condition IsLocalDevEnvironment, !Condition IsDevEnvironment ]
+  IsNotDevEnvironment: !Not
+    - !Condition IsDevLikeEnvironment
 
 Globals:
   Function:
     Timeout: 30
     CodeUri: ..
     Runtime: nodejs18.x
-    Architectures: [arm64]
+    Architectures: [ arm64 ]
+
+Mappings:
+  CriButtonOnCoreStub:
+    Environment:
+      dev: 3
+      build: 5
+      staging: 8
 
 Resources:
+
+  NinoHappyCanariesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevEnvironment
+    Properties:
+      AlarmDescription: "Alarm for when Nino Canaries Fail"
+      AlarmName: "nino-happy-canaries-failure"
+      ActionsEnabled: true
+      Namespace: "CloudWatchSynthetics"
+      MetricName: "Failed"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Statistic: Sum
+      Period: 3600
+      Threshold: 3
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      Dimensions:
+        - Name: "CanaryName"
+          Value: !Ref NinoHappyCanaries
+
+  NinoCICanariesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevEnvironment
+    Properties:
+      AlarmDescription: "Alarm for when Nino Canaries Fail"
+      AlarmName: "nino-ci-canaries-failure"
+      ActionsEnabled: true
+      Namespace: "CloudWatchSynthetics"
+      MetricName: "Failed"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Statistic: Sum
+      Period: 3600
+      Threshold: 3
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      Dimensions:
+        - Name: "CanaryName"
+          Value: !Ref NinoCICanaries
+
+  CanariesRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Principal:
+              Service:
+                - synthetics.amazonaws.com
+                - lambda.amazonaws.com
+      Policies:
+        - PolicyName: NinoCanariesExecutionRole
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Resource: "*"
+                Action:
+                  - s3:PutObject
+                  - s3:GetBucketLocation
+                  - s3:ListAllMyBuckets
+                  - cloudwatch:PutMetricData
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+
+  CanariesBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub ${AWS::StackName}-check-canaries-bucket
+
   CanaryInvokerFunction:
     Type: AWS::Serverless::Function
     Metadata:
@@ -38,7 +124,7 @@ Resources:
       LoggingConfig:
         LogGroup: !Sub /aws/lambda/${AWS::StackName}/CanaryInvokerFunction
       CodeSigningConfigArn:
-        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+        !If [ EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue ]
       Policies:
         - Statement:
             Effect: Allow
@@ -52,6 +138,244 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CanaryInvokerFunction
       RetentionInDays: !If [ IsDevLikeEnvironment, 7, 30 ]
+
+  NinoCICanaries:
+    Type: AWS::Synthetics::Canary
+    Properties:
+      Name: nino-ci
+      StartCanaryAfterCreation: true
+      ArtifactS3Location: !Sub s3://${CanariesBucket}/ci
+      ExecutionRoleArn: !GetAtt CanariesRole.Arn
+      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      Schedule:
+        Expression: rate(15 minutes)
+      Tags:
+        - Key: blueprint
+          Value: canaryRecorder
+        - Key: code location
+          Value: ipv-cri-check-hmrc-smoke-tests
+      Code:
+        Handler: exports.handler
+        Script:
+          !Sub
+          - |
+            var synthetics = require('Synthetics');
+            const log = require('SyntheticsLogger');
+            const escapeXpathString = (str) => {
+              return str.replace(/'/g, `', "'", '`);
+            };
+            const clickByText = async (page, text) => {
+              const escapedText = escapeXpathString(text);
+              const linkHandlers = await page.$x("//a[contains(text(), '" + escapedText + "')]");
+              if (linkHandlers.length > 0) {
+                await linkHandlers[0].click();
+              } else {
+                throw new Error('Link not found:' + text);
+              }
+            };
+            const recordedScript = async function () {
+              let page = await synthetics.getPage();
+              const navigationPromise = page.waitForNavigation()
+              await synthetics.executeStep('Goto Stubs Page', async function() {
+                await page.goto("${CoreStubUrl}", { waitUntil: 'domcontentloaded', timeout: 60000 })
+              })
+              await page.setViewport({ width: 1364, height: 695 })
+              await synthetics.executeStep('Click Check HMRC Build Evidence Requested', async function() {
+                await page.waitForSelector('.govuk-template__body > .govuk-width-container > #main-content > a:nth-child(${CoreStubButton}) > .govuk-button')
+                await page.click('.govuk-template__body > .govuk-width-container > #main-content > a:nth-child(${CoreStubButton}) > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click Continue on Evidence Requested page', async function() {
+                await page.waitForSelector('form > .govuk-form-group > .govuk-fieldset > .govuk-button-group > .govuk-button')
+                await page.click('form > .govuk-form-group > .govuk-fieldset > .govuk-button-group > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep("Click New User Hyperlink", async function () {
+                await clickByText(page, "New User");
+              });
+              await navigationPromise
+              await synthetics.executeStep('Click Firstname Box', async function() {
+                await page.waitForSelector('.govuk-width-container > #main-content #firstName')
+                await page.click('.govuk-width-container > #main-content #firstName')
+              })
+              await synthetics.executeStep('Enter Firstname', async function() {
+                await page.type('.govuk-width-container > #main-content #firstName', "Error")
+              })
+              await synthetics.executeStep('Click Surname Box', async function() {
+                await page.waitForSelector('.govuk-width-container > #main-content #surname')
+                await page.click('.govuk-width-container > #main-content #surname')
+              })
+              await synthetics.executeStep('Enter Surname', async function() {
+                await page.type('.govuk-width-container > #main-content #surname', "NoCidForNino")
+              })
+              await synthetics.executeStep('Click Go', async function() {
+                await page.waitForSelector('.govuk-template__body > .govuk-width-container > #main-content > form > .govuk-button')
+                await page.click('.govuk-template__body > .govuk-width-container > #main-content > form > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click NI Box', async function() {
+                await page.waitForSelector('.govuk-grid-row #nationalInsuranceNumber')
+                await page.click('.govuk-grid-row #nationalInsuranceNumber')
+              })
+              await synthetics.executeStep('Enter NINO', async function() {
+                await page.type('.govuk-grid-row #nationalInsuranceNumber', "AA123456C")
+              })
+              await synthetics.executeStep('Click Continue', async function() {
+                await page.waitForSelector('#main-content #continue')
+                await page.click('#main-content #continue')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click Retry Button', async function() {
+                await page.waitForSelector('.govuk-form-group > #retryNationalInsuranceRadio-fieldset #retryNationalInsuranceRadio')
+                await page.click('.govuk-form-group > #retryNationalInsuranceRadio-fieldset #retryNationalInsuranceRadio')
+              })
+              await synthetics.executeStep('Enter Retry NINO', async function() {
+                await page.type('.govuk-form-group > #retryNationalInsuranceRadio-fieldset #retryNationalInsuranceRadio', "retryNationalInsurance")
+              })
+              await synthetics.executeStep('Click Continue', async function() {
+                await page.waitForSelector('#main-content #continue')
+                await page.click('#main-content #continue')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click Continue', async function() {
+                await page.waitForSelector('#main-content #continue')
+                await page.click('#main-content #continue')
+              })
+              await navigationPromise
+              await synthetics.executeStep('VerifyVerifiableCredentials', async function() {
+                const spanSelector = '.govuk-details__summary-text';
+                await page.waitForSelector(spanSelector, { timeout: 60000 });
+                const headingSelector = '.govuk-heading-l';
+                await page.waitForSelector(headingSelector, { timeout: 60000 });
+              })
+              await synthetics.executeStep('Get VC And Assert CI', async function() {
+                const data = await page.evaluate(() => {
+                  const element = document.querySelector("[id='data']");
+                  return element.textContent.trim();
+                });
+                log.info('Extracted data:', data);
+                const json = JSON.parse(data);
+                if (!json.vc.evidence[0].ci) {
+                  throw new Error("Assertion failed: 'CI' is not present in the data");
+                }
+              })
+            };
+            exports.handler = async () => {
+              return await recordedScript();
+            };
+          - CoreStubUrl: !Sub "{{resolve:ssm:/check-hmrc-cri-api/core-stub-url}}"
+            CoreStubButton: !FindInMap [CriButtonOnCoreStub, "Environment", !Ref Environment]
+
+  NinoHappyCanaries:
+    Type: AWS::Synthetics::Canary
+    Properties:
+      Name: nino-happy
+      StartCanaryAfterCreation: true
+      ArtifactS3Location: !Sub s3://${CanariesBucket}/happy
+      ExecutionRoleArn: !GetAtt CanariesRole.Arn
+      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      Schedule:
+        Expression: rate(15 minutes)
+      Tags:
+        - Key: blueprint
+          Value: canaryRecorder
+        - Key: code location
+          Value: ipv-cri-check-hmrc-smoke-tests
+      Code:
+        Handler: exports.handler
+        Script:
+          !Sub
+          - |
+            var synthetics = require('Synthetics');
+            const log = require('SyntheticsLogger');
+            const escapeXpathString = (str) => {
+              return str.replace(/'/g, `', "'", '`);
+            };
+            const clickByText = async (page, text) => {
+              const escapedText = escapeXpathString(text);
+              const linkHandlers = await page.$x("//a[contains(text(), '" + escapedText + "')]");
+              if (linkHandlers.length > 0) {
+                await linkHandlers[0].click();
+              } else {
+                throw new Error('Link not found:' + text);
+              }
+            };
+            const recordedScript = async function () {
+              let page = await synthetics.getPage();
+              const navigationPromise = page.waitForNavigation()
+              await synthetics.executeStep('Goto Stubs Page', async function() {
+                const url = '${CoreStubUrl}';
+                await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 })
+              })
+              await page.setViewport({ width: 1364, height: 695 })
+              await synthetics.executeStep('Click Check HMRC Build Evidence Requested', async function() {
+                await page.waitForSelector('.govuk-template__body > .govuk-width-container > #main-content > a:nth-child(${CoreStubButton}) > .govuk-button')
+                await page.click('.govuk-template__body > .govuk-width-container > #main-content > a:nth-child(${CoreStubButton}) > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click Continue on Evidence Requested page', async function() {
+                await page.waitForSelector('form > .govuk-form-group > .govuk-fieldset > .govuk-button-group > .govuk-button')
+                await page.click('form > .govuk-form-group > .govuk-fieldset > .govuk-button-group > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep("Click New User Hyperlink", async function () {
+                await clickByText(page, "New User");
+              });
+              await navigationPromise
+              await synthetics.executeStep('Click Firstname Box', async function() {
+                await page.waitForSelector('.govuk-width-container > #main-content #firstName')
+                await page.click('.govuk-width-container > #main-content #firstName')
+              })
+              await synthetics.executeStep('Enter Firstname', async function() {
+                await page.type('.govuk-width-container > #main-content #firstName', "Jim")
+              })
+              await synthetics.executeStep('Click Surname Box', async function() {
+                await page.waitForSelector('.govuk-width-container > #main-content #surname')
+                await page.click('.govuk-width-container > #main-content #surname')
+              })
+              await synthetics.executeStep('Enter Surname', async function() {
+                await page.type('.govuk-width-container > #main-content #surname', "Ferguson")
+              })
+              await synthetics.executeStep('Click Go', async function() {
+                await page.waitForSelector('.govuk-template__body > .govuk-width-container > #main-content > form > .govuk-button')
+                await page.click('.govuk-template__body > .govuk-width-container > #main-content > form > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click NI Box', async function() {
+                await page.waitForSelector('.govuk-grid-row #nationalInsuranceNumber')
+                await page.click('.govuk-grid-row #nationalInsuranceNumber')
+              })
+              await synthetics.executeStep('Enter NINO', async function() {
+                await page.type('.govuk-grid-row #nationalInsuranceNumber', "AA123456C")
+              })
+              await synthetics.executeStep('Click Continue', async function() {
+                await page.waitForSelector('#main-content #continue')
+                await page.click('#main-content #continue')
+              })
+              await navigationPromise
+              await synthetics.executeStep('VerifyVerifiableCredentials', async function() {
+                const spanSelector = '.govuk-details__summary-text';
+                await page.waitForSelector(spanSelector, { timeout: 60000 });
+                const headingSelector = '.govuk-heading-l';
+                await page.waitForSelector(headingSelector, { timeout: 60000 });
+              })
+              await synthetics.executeStep('Get VC And Assert CI', async function() {
+                const data = await page.evaluate(() => {
+                  const element = document.querySelector("[id='data']");
+                  return element.textContent.trim();
+                });
+                log.info('Extracted data:', data);
+                const json = JSON.parse(data);
+                if (json.vc.evidence[0].ci) {
+                  throw new Error("Assertion failed: CI is present in the data");
+                }
+              })
+            };
+            exports.handler = async () => {
+              return await recordedScript();
+            };
+          - CoreStubUrl: !Sub "{{resolve:ssm:/check-hmrc-cri-api/core-stub-url}}"
+            CoreStubButton: !FindInMap [CriButtonOnCoreStub, "Environment", !Ref Environment]
 
 Outputs:
   CanaryInvokerFunction:

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -20,6 +20,7 @@ Conditions:
     !Or [ !Condition IsLocalDevEnvironment, !Condition IsDevEnvironment ]
   IsNotDevEnvironment: !Not
     - !Condition IsDevLikeEnvironment
+  IsProdEnvironment: !Equals [ !Ref Environment, production ]
 
 Globals:
   Function:
@@ -137,7 +138,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/CanaryInvokerFunction
-      RetentionInDays: !If [ IsDevLikeEnvironment, 7, 30 ]
+      RetentionInDays: !If [ IsProdEnvironment, 30, 7 ]
 
   NinoCICanaries:
     Type: AWS::Synthetics::Canary

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -2,7 +2,7 @@
 set -eu
 
 lambda_function_name=$(aws cloudformation describe-stacks --stack-name ipv-cri-check-hmrc-smoke-tests --query "Stacks[0].Outputs[?OutputKey=='CanaryInvokerFunction'].OutputValue" --output text)
-canary_names=("nino-canaries")
+canary_names=("nino-happy" "nino-ci")
 
 for canary_name in "${canary_names[@]}"; do
     payload="{ \"canaryName\": \"$canary_name\" }"


### PR DESCRIPTION
## Proposed changes

### What changed
* Added Synthetic canaries into the template
* Added alarms to trigger on failures
* Made the canary work choose the correct CRI button using the Environment parameter
* Updated the tests so that we just check for a CI instead of exact values
* Core stub URL is now being looked up from SSM because it contained credentials


### Why did it change
The synthetics were clicked ops so we needed to make this infrastructure as code.

### Issue tracking
- [OJ-2342](https://govukverify.atlassian.net/browse/OJ-2342)


[OJ-2342]: https://govukverify.atlassian.net/browse/OJ-2342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ