### PR TITLE
Oj 2558 3rd Party Canaries

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -44,6 +44,27 @@ Mappings:
 
 Resources:
 
+  Nino3rdPartyHappyCanariesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevEnvironment
+    Properties:
+      AlarmDescription: "Alarm for when Nino 3rd Party Canaries Fail"
+      AlarmName: "nino-3rd-party-canaries-failure"
+      ActionsEnabled: true
+      Namespace: "CloudWatchSynthetics"
+      MetricName: "Failed"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Statistic: Sum
+      Period: 3600
+      Threshold: 3
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      Dimensions:
+        - Name: "CanaryName"
+          Value: !Ref NinoHappyCanaries3rdParty
+
   NinoHappyCanariesAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: IsNotDevEnvironment
@@ -85,6 +106,27 @@ Resources:
       Dimensions:
         - Name: "CanaryName"
           Value: !Ref NinoCICanaries
+
+  Nino3rdPartyCICanariesAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevEnvironment
+    Properties:
+      AlarmDescription: "Alarm for when Nino 3rd Party Canaries Fail"
+      AlarmName: "nino-3rd-party-ci-failure"
+      ActionsEnabled: true
+      Namespace: "CloudWatchSynthetics"
+      MetricName: "Failed"
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      EvaluationPeriods: 1
+      Statistic: Sum
+      Period: 3600
+      Threshold: 3
+      TreatMissingData: notBreaching
+      AlarmActions:
+        - !ImportValue platform-alarm-warning-alert-topic
+      Dimensions:
+        - Name: "CanaryName"
+          Value: !Ref NinoCICanaries3rdParty
 
   CanariesRole:
     Type: AWS::IAM::Role
@@ -382,6 +424,274 @@ Resources:
               return await recordedScript();
             };
           - CoreStubUrl: !Sub "{{resolve:ssm:/check-hmrc-cri-api/smoke-tests/core-stub-url}}"
+            CoreStubButton: !FindInMap [CriButtonOnCoreStub, "Environment", !Ref Environment]
+
+  NinoCICanaries3rdParty:
+    Type: AWS::Synthetics::Canary
+    Properties:
+      Name: !Sub ${AWS::StackName}-3rdci
+      StartCanaryAfterCreation: true
+      ArtifactS3Location: !Sub s3://${CanariesBucket}/ci
+      ExecutionRoleArn: !GetAtt CanariesRole.Arn
+      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      Schedule:
+        Expression: rate(15 minutes)
+      Tags:
+        - Key: blueprint
+          Value: canaryRecorder
+        - Key: code location
+          Value: ipv-cri-check-hmrc-smoke-tests
+      Code:
+        Handler: exports.handler
+        Script:
+          !Sub
+          - |
+            var synthetics = require('Synthetics');
+            const log = require('SyntheticsLogger');
+            const escapeXpathString = (str) => {
+              return str.replace(/'/g, `', "'", '`);
+            };
+            const clickByText = async (page, text) => {
+              const escapedText = escapeXpathString(text);
+              const linkHandlers = await page.$x("//a[contains(text(), '" + escapedText + "')]");
+              if (linkHandlers.length > 0) {
+                await linkHandlers[0].click();
+              } else {
+                throw new Error('Link not found:' + text);
+              }
+            };
+            const recordedScript = async function () {
+              let page = await synthetics.getPage();
+              const navigationPromise = page.waitForNavigation()
+              await synthetics.executeStep('Goto Stubs Page', async function() {
+                await page.goto("${CoreStubUrl}", { waitUntil: 'domcontentloaded', timeout: 60000 })
+              })
+              await page.setViewport({ width: 1364, height: 695 })
+              await synthetics.executeStep('Click Check HMRC Build Evidence Requested', async function() {
+                await page.waitForSelector('.govuk-template__body > .govuk-width-container > #main-content > a:nth-child(${CoreStubButton}) > .govuk-button')
+                await page.click('.govuk-template__body > .govuk-width-container > #main-content > a:nth-child(${CoreStubButton}) > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click Continue on Evidence Requested page', async function() {
+                await page.waitForSelector('form > .govuk-form-group > .govuk-fieldset > .govuk-button-group > .govuk-button')
+                await page.click('form > .govuk-form-group > .govuk-fieldset > .govuk-button-group > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep("Click New User Hyperlink", async function () {
+                await clickByText(page, "New User");
+              });
+              await navigationPromise
+              await synthetics.executeStep('Click Firstname Box', async function() {
+                await page.waitForSelector('.govuk-width-container > #main-content #firstName')
+                await page.click('.govuk-width-container > #main-content #firstName')
+              })
+              await synthetics.executeStep('Enter Firstname', async function() {
+                await page.type('.govuk-width-container > #main-content #firstName', "Error")
+              })
+              await synthetics.executeStep('Click Surname Box', async function() {
+                await page.waitForSelector('.govuk-width-container > #main-content #surname')
+                await page.click('.govuk-width-container > #main-content #surname')
+              })
+              await synthetics.executeStep('Enter Surname', async function() {
+                await page.type('.govuk-width-container > #main-content #surname', "NoCidForNino")
+              })
+              await synthetics.executeStep('Click Go', async function() {
+                await page.waitForSelector('.govuk-template__body > .govuk-width-container > #main-content > form > .govuk-button')
+                await page.click('.govuk-template__body > .govuk-width-container > #main-content > form > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click NI Box', async function() {
+                await page.waitForSelector('.govuk-grid-row #nationalInsuranceNumber')
+                await page.click('.govuk-grid-row #nationalInsuranceNumber')
+              })
+              await synthetics.executeStep('Enter NINO', async function() {
+                await page.type('.govuk-grid-row #nationalInsuranceNumber', "AA123456C")
+              })
+              await synthetics.executeStep('Click Continue', async function() {
+                await page.waitForSelector('#main-content #continue')
+                await page.click('#main-content #continue')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click Retry Button', async function() {
+                await page.waitForSelector('.govuk-form-group > #retryNationalInsuranceRadio-fieldset #retryNationalInsuranceRadio')
+                await page.click('.govuk-form-group > #retryNationalInsuranceRadio-fieldset #retryNationalInsuranceRadio')
+              })
+              await synthetics.executeStep('Enter Retry NINO', async function() {
+                await page.type('.govuk-form-group > #retryNationalInsuranceRadio-fieldset #retryNationalInsuranceRadio', "retryNationalInsurance")
+              })
+              await synthetics.executeStep('Click Continue', async function() {
+                await page.waitForSelector('#main-content #continue')
+                await page.click('#main-content #continue')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click Continue', async function() {
+                await page.waitForSelector('#main-content #continue')
+                await page.click('#main-content #continue')
+              })
+              await navigationPromise
+              await synthetics.executeStep('VerifyVerifiableCredentials', async function() {
+                const spanSelector = '.govuk-details__summary-text';
+                await page.waitForSelector(spanSelector, { timeout: 60000 });
+                const headingSelector = '.govuk-heading-l';
+                await page.waitForSelector(headingSelector, { timeout: 60000 });
+              })
+              await synthetics.executeStep('Get VC And Assert CI', async function() {
+                const data = await page.evaluate(() => {
+                  const element = document.querySelector("[id='data']");
+                  return element.textContent.trim();
+                });
+                log.info('Extracted data:', data);
+                const json = JSON.parse(data);
+                if (!json.vc.evidence[0].ci) {
+                  throw new Error("Assertion failed: 'CI' is not present in the data");
+                }
+              })
+            };
+            exports.handler = async () => {
+              return await recordedScript();
+            };
+          - CoreStubUrl: !Sub "{{resolve:ssm:/check-hmrc-cri-api/smoke-tests/core-stub-url-3rdparty}}"
+            CoreStubButton: !FindInMap [CriButtonOnCoreStub, "Environment", !Ref Environment]
+
+  NinoHappyCanaries3rdParty:
+    Type: AWS::Synthetics::Canary
+    Properties:
+      Name:  !Sub ${AWS::StackName}-3rd
+      StartCanaryAfterCreation: true
+      ArtifactS3Location: !Sub s3://${CanariesBucket}/happy
+      ExecutionRoleArn: !GetAtt CanariesRole.Arn
+      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      Schedule:
+        Expression: rate(15 minutes)
+      Tags:
+        - Key: blueprint
+          Value: canaryRecorder
+        - Key: code location
+          Value: ipv-cri-check-hmrc-smoke-tests
+      Code:
+        Handler: exports.handler
+        Script:
+          !Sub
+          - |
+            var synthetics = require('Synthetics');
+            const log = require('SyntheticsLogger');
+            const escapeXpathString = (str) => {
+              return str.replace(/'/g, `', "'", '`);
+            };
+            const clickByText = async (page, text) => {
+              const escapedText = escapeXpathString(text);
+              const linkHandlers = await page.$x("//a[contains(text(), '" + escapedText + "')]");
+              if (linkHandlers.length > 0) {
+                await linkHandlers[0].click();
+              } else {
+                throw new Error('Link not found:' + text);
+              }
+            };
+            const recordedScript = async function () {
+              let page = await synthetics.getPage();
+              const navigationPromise = page.waitForNavigation()
+              await synthetics.executeStep('Goto Stubs Page', async function() {
+                const url = '${CoreStubUrl}';
+                await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 })
+              })
+              await page.setViewport({ width: 1364, height: 695 })
+              await synthetics.executeStep('Click Check HMRC Build Evidence Requested', async function() {
+                await page.waitForSelector('.govuk-template__body > .govuk-width-container > #main-content > a:nth-child(${CoreStubButton}) > .govuk-button')
+                await page.click('.govuk-template__body > .govuk-width-container > #main-content > a:nth-child(${CoreStubButton}) > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click Continue on Evidence Requested page', async function() {
+                await page.waitForSelector('form > .govuk-form-group > .govuk-fieldset > .govuk-button-group > .govuk-button')
+                await page.click('form > .govuk-form-group > .govuk-fieldset > .govuk-button-group > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep("Click New User Hyperlink", async function () {
+                await clickByText(page, "New User");
+              });
+              await navigationPromise
+              await synthetics.executeStep('Click Firstname Box', async function() {
+                await page.waitForSelector('.govuk-width-container > #main-content #firstName')
+                await page.click('.govuk-width-container > #main-content #firstName')
+              })
+              await synthetics.executeStep('Enter Firstname', async function() {
+                await page.type('.govuk-width-container > #main-content #firstName', "Jim")
+              })
+              await synthetics.executeStep('Click Surname Box', async function() {
+                await page.waitForSelector('.govuk-width-container > #main-content #surname')
+                await page.click('.govuk-width-container > #main-content #surname')
+              })
+              await synthetics.executeStep('Enter Surname', async function() {
+                await page.type('.govuk-width-container > #main-content #surname', "Ferguson")
+              })
+              await synthetics.executeStep('Click Day field', async function() {
+                await page.waitForSelector('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-day')
+                await page.click('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-day')
+              })
+              await page.evaluate(() => {
+                    document.querySelector('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-day').value = '';
+              });
+              await synthetics.executeStep('Enter Day in field', async function() {
+                await page.type('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-day', "23")
+              })
+              await synthetics.executeStep('Click Month field', async function() {
+                await page.waitForSelector('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-month')
+                await page.click('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-month')
+              })
+              await page.evaluate(() => {
+                    document.querySelector('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-month').value = '';
+              });
+              await synthetics.executeStep('Enter Month in field', async function() {
+                await page.type('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-month', "4")
+              })
+              await synthetics.executeStep('Click Year field', async function() {
+                await page.waitForSelector('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-year')
+                await page.click('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-year')
+              })
+              await page.evaluate(() => {
+                    document.querySelector('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-year').value = '';
+               });
+              await synthetics.executeStep('Enter Year in field', async function() {
+                await page.type('#dateOfBirth-fieldset > #dateOfBirth #dateOfBirth-year', "1948")
+              })
+              await synthetics.executeStep('Click Go', async function() {
+                await page.waitForSelector('.govuk-template__body > .govuk-width-container > #main-content > form > .govuk-button')
+                await page.click('.govuk-template__body > .govuk-width-container > #main-content > form > .govuk-button')
+              })
+              await navigationPromise
+              await synthetics.executeStep('Click NI Box', async function() {
+                await page.waitForSelector('.govuk-grid-row #nationalInsuranceNumber')
+                await page.click('.govuk-grid-row #nationalInsuranceNumber')
+              })
+              await synthetics.executeStep('Enter NINO', async function() {
+                await page.type('.govuk-grid-row #nationalInsuranceNumber', "AA000003D")
+              })
+              await synthetics.executeStep('Click Continue', async function() {
+                await page.waitForSelector('#main-content #continue')
+                await page.click('#main-content #continue')
+              })
+              await navigationPromise
+              await synthetics.executeStep('VerifyVerifiableCredentials', async function() {
+                const spanSelector = '.govuk-details__summary-text';
+                await page.waitForSelector(spanSelector, { timeout: 60000 });
+                const headingSelector = '.govuk-heading-l';
+                await page.waitForSelector(headingSelector, { timeout: 60000 });
+              })
+              await synthetics.executeStep('Get VC And Assert CI', async function() {
+                const data = await page.evaluate(() => {
+                  const element = document.querySelector("[id='data']");
+                  return element.textContent.trim();
+                });
+                log.info('Extracted data:', data);
+                const json = JSON.parse(data);
+                if (json.vc.evidence[0].ci) {
+                  throw new Error("Assertion failed: CI is present in the data");
+                }
+              })
+            };
+            exports.handler = async () => {
+              return await recordedScript();
+            };
+          - CoreStubUrl: !Sub "{{resolve:ssm:/check-hmrc-cri-api/smoke-tests/core-stub-url-3rdparty}}"
             CoreStubButton: !FindInMap [CriButtonOnCoreStub, "Environment", !Ref Environment]
 
 Outputs:


### PR DESCRIPTION
## Proposed changes

### What changed

We have added the 3rd party canaries and alarms to the template.yaml 
ssm parameters were updated in the check-hmrc-dev account to include the `core-stub-url` and the `core-stub-url-3rd-party` secrets.

### Why did it change

To increase test coverage.

### Issue tracking

- [OJ-2558](https://govukverify.atlassian.net/browse/OJ-2558)

## Checklists

### Environment variables or secrets


- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2558]: https://govukverify.atlassian.net/browse/OJ-2558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ