### PR TITLE
OJ-2543: Fix canary invoker lambda

### DIFF
--- a/lambdas/canary-invoker/src/canary-invoker-handler.ts
+++ b/lambdas/canary-invoker/src/canary-invoker-handler.ts
@@ -1,59 +1,147 @@
 import { LambdaInterface } from "@aws-lambda-powertools/commons";
 import { Logger } from "@aws-lambda-powertools/logger";
 import {
-    GetCanaryRunsCommand,
-    StartCanaryCommand,
-    SyntheticsClient,
+  CanaryState,
+  GetCanaryCommand,
+  GetCanaryResponse,
+  GetCanaryRunsCommand,
+  StartCanaryCommand,
+  StopCanaryCommand,
+  SyntheticsClient,
 } from "@aws-sdk/client-synthetics";
 
 const logger = new Logger();
 const client = new SyntheticsClient();
 
 export class CanaryInvokerHandler implements LambdaInterface {
-    public async handler(
-      event: { canaryName: string },
-      _context: unknown
-    ): Promise<{}> {
-        try {
-            logger.info(`Running ${event.canaryName}`);
+  public async handler(
+    event: { canaryName: string },
+    _context: unknown
+  ): Promise<void> {
+    try {
+      logger.info(`Running ${event.canaryName}`);
 
-            const previousRuns = await client.send(new GetCanaryRunsCommand({
-                Name: event.canaryName
-            }));
+      const previousRunId = await getPreviousCanaryRunId(event.canaryName);
 
-            const previousRunId = previousRuns?.CanaryRuns?.at(0)?.Id;
-            const startCanary = await client.send(new StartCanaryCommand({ Name: event.canaryName }));
-            const startCanaryStatusCode = startCanary.$metadata.httpStatusCode;
+      let canary = await getLatestCanaryStatus(event.canaryName);
 
-            if(startCanaryStatusCode !== 200) {
-                throw new Error(`Failed to invoke canary received ${startCanaryStatusCode}`)
-            }
+      if (canary.Canary?.Status?.State == CanaryState.RUNNING) {
+        logger.info(event.canaryName + " is already running, stopping...");
 
-            const interval = setInterval(async () => {
-                const canaryRuns = await client.send(new GetCanaryRunsCommand({
-                    Name: event.canaryName
-                }));
+        const stopCanary = await client.send(
+          new StopCanaryCommand({
+            Name: event.canaryName,
+          })
+        );
 
-                const runStatus = canaryRuns?.CanaryRuns?.at(0);
+        const stopCanaryStatusCode = stopCanary.$metadata.httpStatusCode;
 
-                if (runStatus?.Id !== previousRunId) {
-                    clearInterval(interval);
-                    if (runStatus?.Status?.State === "PASSED") {
-                        return "Canary has passed";
-                    } else {
-                        throw new Error("Canary did not pass: " + runStatus?.Status?.StateReason);
-                    }
-                }
-            }, 5000);
-
-            await new Promise(resolve => setTimeout(resolve, 60000));
-
-            throw new Error("Test timed out")
-        } catch (error) {
-            logger.error('Error executing canary:' + error);
-            throw error;
+        if (stopCanaryStatusCode !== 200) {
+          throw new Error(
+            `Failed to stop already running canary, received ${stopCanaryStatusCode}`
+          );
         }
+      }
+
+      canary = await getLatestCanaryStatus(event.canaryName);
+
+      if (canary.Canary?.Status?.State != CanaryState.STOPPED) {
+        await waitForCanaryToStop(event.canaryName);
+      }
+
+      logger.info("Starting canary " + event.canaryName);
+      await startCanary(event.canaryName);
+
+      const hasPassed = await waitForCanaryToPass(
+        event.canaryName,
+        previousRunId
+      );
+
+      if (hasPassed) {
+        logger.info(event.canaryName + " has passed");
+        return;
+      }
+
+      logger.error(event.canaryName + " has failed");
+    } catch (error) {
+      logger.error("Error executing canary:" + error);
+      throw error;
     }
+  }
+}
+
+async function waitForCanaryToStop(canaryName: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const interval = setInterval(async () => {
+      const canary = await client.send(
+        new GetCanaryCommand({
+          Name: canaryName,
+        })
+      );
+      if (canary.Canary?.Status?.State == CanaryState.STOPPED) {
+        clearInterval(interval);
+        logger.info("Stopped existing canary run successfully");
+        resolve();
+      }
+    }, 5000);
+  });
+}
+
+async function waitForCanaryToPass(
+  canaryName: string,
+  previousRunId: string
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const interval = setInterval(async () => {
+      const canaryRuns = await client.send(
+        new GetCanaryRunsCommand({
+          Name: canaryName,
+        })
+      );
+      const runStatus = canaryRuns?.CanaryRuns?.at(0);
+      if (runStatus?.Id !== previousRunId) {
+        clearInterval(interval);
+        if (runStatus?.Status?.State === "PASSED") {
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      }
+    }, 5000);
+  });
+}
+
+async function getLatestCanaryStatus(
+  canaryName: string
+): Promise<GetCanaryResponse> {
+  return client.send(
+    new GetCanaryCommand({
+      Name: canaryName,
+    })
+  );
+}
+
+async function getPreviousCanaryRunId(canaryName: string): Promise<string> {
+  const previousRuns = await client.send(
+    new GetCanaryRunsCommand({
+      Name: canaryName,
+    })
+  );
+  return previousRuns?.CanaryRuns?.at(0)?.Id || "";
+}
+
+async function startCanary(canaryName: string) {
+  const startCanary = await client.send(
+    new StartCanaryCommand({ Name: canaryName })
+  );
+
+  const startCanaryStatusCode = startCanary.$metadata.httpStatusCode;
+
+  if (startCanaryStatusCode !== 200) {
+    throw new Error(
+      `Failed to invoke canary received ${startCanaryStatusCode}`
+    );
+  }
 }
 
 const handlerClass = new CanaryInvokerHandler();


### PR DESCRIPTION
## Proposed changes

### What changed
The canary invoker lambda has been changed.

### Why did it change
When this Lambda was created the canaries were not yet on a schedule. Since they run on a schedule now the status on a canary is always "running", this means that the lambda cannot start an already running canary.

The important change added to lambda is that it now stops the canary if it's state is "running".
Additionally, some clean up and refactoring has been done to the lambda as the handle method was getting big and confusing. 

Additional logging has also been added.

### Issue tracking
- [OJ-2543](https://govukverify.atlassian.net/browse/OJ-2543)

[OJ-2543]: https://govukverify.atlassian.net/browse/OJ-2543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ