### PR TITLE
OJ-2543: Allow jq to read the output file without a pseudoterminal

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Push Docker image
         uses: govuk-one-login/github-actions/aws/ecr/build-docker-image@3b8133beab89c813cf15375904be82bf9ab79a91
-        if: ${{ github.event_name == 'push' || matrix.environment == 'development' }}
+        if: ${{ github.ref_name == 'main' || matrix.environment == 'development' }}
         with:
           immutable-tags: false
           image-version: ${{ github.sha }}

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -16,7 +16,7 @@ Parameters:
     Default: ""
   DeployAlarmsInDevEnvironment:
     Type: String
-    Default: false
+    Default: "false"
 
 Conditions:
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       }
     },
     "lambdas/cloudformation": {
+      "extraneous": true,
       "dependencies": {
         "@aws-sdk/client-cloudformation": "^3.600.0"
       }
@@ -239,6 +240,7 @@
       "version": "3.600.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.600.0.tgz",
       "integrity": "sha512-7VCYmqF/RTOjTruvMxEEY/2t7f72L6VTVBow06+scqo4lFkgUjUfk416V163dhxrvstngG0cXD6hZRJewEzaww==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -293,6 +295,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.2.0.tgz",
       "integrity": "sha512-cKyeKAPazZRVqm7QPvcPD2jEIt2wqDPAL1KJKb0f/5I7uhollvsWZuZKLclmyP6a+Jwmr3OV3t+X0pZUUHS9BA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3841,6 +3844,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-3.1.1.tgz",
       "integrity": "sha512-xT+Bbpe5sSrC7cCWSElOreDdWzqovR1V+7xrp+fmwGAA+TPYBb78iasaXjO1pa+65sY6JjW5GtGeIoJwCK9B1g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/abort-controller": "^3.1.0",
@@ -3855,6 +3859,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.2.0.tgz",
       "integrity": "sha512-cKyeKAPazZRVqm7QPvcPD2jEIt2wqDPAL1KJKb0f/5I7uhollvsWZuZKLclmyP6a+Jwmr3OV3t+X0pZUUHS9BA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4883,10 +4888,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/cloudformation": {
-      "resolved": "lambdas/cloudformation",
-      "link": true
     },
     "node_modules/cls-hooked": {
       "version": "4.2.2",

--- a/test-image/run-tests.sh
+++ b/test-image/run-tests.sh
@@ -73,7 +73,7 @@ for canary in "${canaries[@]}"; do
 
   if [[ $(jq 'has("FunctionError")' <<< "$canary_result") == true ]]; then
     echo "  𝑥 Lambda invocation failed for canary $canary"
-    jq < "$output_file"
+    jq . "$output_file"
     success=false
   elif [[ $(jq --raw-output '.passed' "$output_file") == true ]]; then
     echo "  ✔ Successfully ran canary $canary"


### PR DESCRIPTION
 jq doesn't accept input redirect without a tty and returns with an error. Pass the file as an argument to the program instead.

Updated `package.json` too, and fixed type validation for `DeployAlarmsInDevEnvironment` param.

Changed the docker image action to push an image to build also on a manual trigger.
