### PR TITLE
BAU: Set environment in the samconfig.toml file

### DIFF
--- a/infrastructure/samconfig.toml
+++ b/infrastructure/samconfig.toml
@@ -14,6 +14,10 @@ s3_prefix = "localdev"
 region = "eu-west-2"
 resolve_s3 = true
 
+parameter_overrides = [
+    "Environment=dev"
+]
+
 tags = [
     "cri:component=ipv-cri-check-hmrc-smoke-tests",
     "cri:deployment-source=manual",


### PR DESCRIPTION
Just in case, instead of relying on the default value to be dev