### PR TITLE
OJ-2658: Fix canary alarms

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -50,16 +50,18 @@ Resources:
     Condition: DeployAlarms
     Properties:
       AlarmName: !Sub ${Nino3rdPartyHappyCanary}-canary-failure
-      AlarmDescription: !Sub Triggers when the ${Nino3rdPartyHappyCanary} canary fails three times within an hour
+      AlarmDescription: !Sub Triggers when the ${Nino3rdPartyHappyCanary} canary success percentage is <75 or no data present
       ActionsEnabled: true
-      Namespace: SmokeTests
-      MetricName: Failed
-      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Namespace: CloudWatchSynthetics
+      MetricName: SuccessPercent
+      ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
-      Statistic: Sum
+      Statistic: Average
       Period: 3600
-      Threshold: 3
-      TreatMissingData: notBreaching
+      Threshold: 75
+      TreatMissingData: breaching
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       Dimensions:
@@ -71,16 +73,18 @@ Resources:
     Condition: DeployAlarms
     Properties:
       AlarmName: !Sub ${NinoHappyCanary}-canary-failure
-      AlarmDescription: !Sub Triggers when the ${NinoHappyCanary} canary fails three times within an hour
+      AlarmDescription: !Sub Triggers when the ${NinoHappyCanary} canary success percentage is <75 or no data present
       ActionsEnabled: true
-      Namespace: SmokeTests
-      MetricName: Failed
-      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Namespace: CloudWatchSynthetics
+      MetricName: SuccessPercent
+      ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
-      Statistic: Sum
+      Statistic: Average
       Period: 3600
-      Threshold: 3
-      TreatMissingData: notBreaching
+      Threshold: 75
+      TreatMissingData: breaching
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       Dimensions:
@@ -92,16 +96,18 @@ Resources:
     Condition: DeployAlarms
     Properties:
       AlarmName: !Sub ${NinoCICanary}-canary-failure
-      AlarmDescription: !Sub Triggers when the ${NinoCICanary} canary fails three times within an hour
+      AlarmDescription: !Sub Triggers when the ${NinoCICanary} canary success percentage is <75 or no data present
       ActionsEnabled: true
-      Namespace: SmokeTests
-      MetricName: Failed
-      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Namespace: CloudWatchSynthetics
+      MetricName: SuccessPercent
+      ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
-      Statistic: Sum
+      Statistic: Average
       Period: 3600
-      Threshold: 3
-      TreatMissingData: notBreaching
+      Threshold: 75
+      TreatMissingData: breaching
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       Dimensions:
@@ -113,16 +119,18 @@ Resources:
     Condition: DeployAlarms
     Properties:
       AlarmName: !Sub ${Nino3rdPartyCICanary}-canary-failure
-      AlarmDescription: !Sub Triggers when the ${Nino3rdPartyCICanary} canary fails three times within an hour
+      AlarmDescription: !Sub Triggers when the ${Nino3rdPartyCICanary} canary success percentage is <75 or no data present
       ActionsEnabled: true
-      Namespace: SmokeTests
-      MetricName: Failed
-      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Namespace: CloudWatchSynthetics
+      MetricName: SuccessPercent
+      ComparisonOperator: LessThanThreshold
       EvaluationPeriods: 1
-      Statistic: Sum
+      Statistic: Average
       Period: 3600
-      Threshold: 3
-      TreatMissingData: notBreaching
+      Threshold: 75
+      TreatMissingData: breaching
+      OKActions:
+        - !ImportValue platform-alarm-warning-alert-topic
       AlarmActions:
         - !ImportValue platform-alarm-warning-alert-topic
       Dimensions:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Change the Alarm Namespaces back to CloudWatchSynthetics. Flip the alarm logic to check the success percentage instead of failure so we can treat no data as breaching. Add OkActions

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
We had canary failures occurring however there was no Slack notification to tell us. We should look into seeing what the problem is and fixing it so we can be alerted sooner when an error occurs. 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-2658](https://govukverify.atlassian.net/browse/OJ-2658)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2658]: https://govukverify.atlassian.net/browse/OJ-2658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ