### PR TITLE
OJ-2824: Empty buckets before deleting a stack

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           all-files: true
 

--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -14,31 +14,41 @@ permissions:
 concurrency: cleanup-dev-${{ github.head_ref || github.ref_name }}
 
 jobs:
-  delete-stacks:
-    name: Delete stale stacks
+  get-stale-stacks:
+    name: Get stale stacks
     runs-on: ubuntu-latest
     environment: development
+    outputs:
+      stacks: ${{ steps.get-stacks.outputs.stack-names-json }}
     steps:
-      - name: Assume AWS Role
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ vars.DEPLOYMENT_ROLE_ARN }}
-          aws-region: eu-west-2
-
       - name: Get stale preview stacks
-        uses: govuk-one-login/github-actions/sam/get-stale-stacks@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@d201191485b645ec856a34e5ca48636cf97b2574
+        id: get-stacks
         with:
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           threshold-days: 14
           stack-name-filter: st
           stack-tag-filters: |
             cri:deployment-source=github-actions
             cri:stack-type=preview
           description: preview
-          env-var-name: STACKS
 
-      - name: Delete stacks
-        if: ${{ env.STACKS != null }}
-        uses: govuk-one-login/github-actions/sam/delete-stacks@3b8133beab89c813cf15375904be82bf9ab79a91
+  delete-stacks:
+    name: Delete ${{ matrix.stack }}
+    needs: get-stale-stacks
+    runs-on: ubuntu-latest
+    environment: development
+    if: ${{ needs.get-stale-stacks.outputs.stacks != '[]' }}
+    strategy:
+      max-parallel: 5
+      fail-fast: false
+      matrix:
+        stack: ${{ fromJSON(needs.get-stale-stacks.outputs.stacks) }}
+    steps:
+      - name: Delete stack
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
-          stack-names: ${{ env.STACKS }}
+          aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          stack-names: ${{ matrix.stack }}
+          empty-buckets: true
           verbose: true

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Get stack name
-        uses: govuk-one-login/github-actions/beautify-branch-name@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/beautify-branch-name@d201191485b645ec856a34e5ca48636cf97b2574
         id: get-stack-name
         with:
           usage: Stack name

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -29,8 +29,9 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/sam/delete-stacks@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
+          empty-buckets: true
           verbose: true

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -25,7 +25,7 @@ jobs:
       cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
     steps:
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/sam/build-application@d201191485b645ec856a34e5ca48636cf97b2574
         id: build
         with:
           template: infrastructure/template.yaml
@@ -48,7 +48,7 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
     steps:
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/sam/deploy-stack@d201191485b645ec856a34e5ca48636cf97b2574
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}

--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -29,7 +29,7 @@ jobs:
         run: exit 0
 
       - name: Push Docker image
-        uses: govuk-one-login/github-actions/aws/ecr/build-docker-image@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/aws/ecr/build-docker-image@d201191485b645ec856a34e5ca48636cf97b2574
         if: ${{ steps.enabled.conclusion == 'success' }}
         with:
           immutable-tags: false

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -21,7 +21,7 @@ jobs:
   #  runs-on: ubuntu-latest
   #  steps:
   #    - name: Run SonarCloud scan
-  #      uses: govuk-one-login/github-actions/code-quality/sonarcloud@3b8133beab89c813cf15375904be82bf9ab79a91
+  #      uses: govuk-one-login/github-actions/code-quality/sonarcloud@d201191485b645ec856a34e5ca48636cf97b2574
   #      with:
   #        sonar-token: ${{ secrets.SONAR_TOKEN }}
   #        github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -33,6 +33,6 @@ jobs:
       security-events: write
     steps:
       - name: Run CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@3b8133beab89c813cf15375904be82bf9ab79a91
+        uses: govuk-one-login/github-actions/code-quality/codeql@d201191485b645ec856a34e5ca48636cf97b2574
         with:
           languages: javascript-typescript


### PR DESCRIPTION
Set the `empty-buckets` flag to true.

Use a matrix strategy for the cleanup job to make the job pass faster, since deleting buckets can be a long-running operation.

<img width="1174" alt="Screenshot 2024-10-29 at 18 32 07" src="https://github.com/user-attachments/assets/a14285c1-ef55-4222-b840-9ae9e7837288">