### PR TITLE
OJ-2903: Update the row number to select the correct tab for testing

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -42,7 +42,7 @@ Mappings:
     Environment:
       dev: 3
       build: 5
-      staging: 8
+      staging: 7
 
 Resources:
   Nino3rdPartyHappyCanaryAlarm:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed

Updated the row number to accommodate the staging change made via clickops 

Dev still works:

<img width="1021" alt="Screenshot 2024-11-12 at 09 00 01" src="https://github.com/user-attachments/assets/a8cd8d24-79aa-4d33-a36e-aa150cd714dc">

<img width="1139" alt="Screenshot 2024-11-12 at 08 57 53" src="https://github.com/user-attachments/assets/93782b7f-c74e-4229-bb27-c3a0fc8c5e7b">

Staging  works when clickOps:

<img width="593" alt="Screenshot 2024-11-12 at 09 02 16" src="https://github.com/user-attachments/assets/c6eeb3cc-4dee-4e21-8913-21bcd2e73a61">

<img width="1215" alt="Screenshot 2024-11-12 at 09 01 49" src="https://github.com/user-attachments/assets/a357a90f-45c9-43d7-a374-6a631c161dcf">


### Why did it change

Failing canaries were happening in staging due to new tab shifting the index of element numbers:

<img width="466" alt="Screenshot 2024-11-07 at 15 55 59" src="https://github.com/user-attachments/assets/a115e727-7752-4e99-8565-d9f712adcd3d">


### Issue tracking

- [OJ-2903](https://govukverify.atlassian.net/browse/OJ-2903)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[OJ-2903]: https://govukverify.atlassian.net/browse/OJ-2903?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ