### PR TITLE
OJ-3049: Update Build SAM GHA and set version

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -25,13 +25,14 @@ jobs:
       cache-restore-keys: ${{ steps.build.outputs.cache-restore-keys }}
     steps:
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@d201191485b645ec856a34e5ca48636cf97b2574
+        uses: govuk-one-login/github-actions/sam/build-application@87ae1213145261e3837cc38d5b9317422acd95c2
         id: build
         with:
           template: infrastructure/template.yaml
           cache-name: check-hmrc-smoke-tests
           pull-repository: true
           source-dir: lambdas
+          sam-version: 1.132.0
 
   deploy:
     name: Deploy stack


### PR DESCRIPTION
## Proposed changes

### What changed

Set sam-version to 1.132.0 for now as there is a bug when running `sam validate --lint` with the latest version 1.133.0

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-3049](https://govukverify.atlassian.net/browse/OJ-3049)

[OJ-3049]: https://govukverify.atlassian.net/browse/OJ-3049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ