### PR TITLE
OJ-2956: upgrade - bump node version to node js 22

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         files: ".*\\.(js|ts)"
         pass_filenames: false
   - repo: https://github.com/aws-cloudformation/cfn-lint
-    rev: v0.86.0
+    rev: v1.27.0
     hooks:
       - id: cfn-lint
         files: .template\.ya?ml$

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -30,7 +30,7 @@ Globals:
   Function:
     Timeout: 30
     CodeUri: ..
-    Runtime: nodejs18.x
+    Runtime: nodejs22.x
     Architectures: [arm64]
     PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundary, !Ref AWS::NoValue]
     Environment:


### PR DESCRIPTION
## Proposed changes

### What changed

Upgrade node version from 18 to 22

### Why did it change

Upgrade node version to use the latest based on the principle.

### Issue tracking

- [OJ-2956](https://govukverify.atlassian.net/browse/OJ-2956)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-2956]: https://govukverify.atlassian.net/browse/OJ-2956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ