### PR TITLE
OJ-3289: refactor - upgrade the syn-nodejs-puppeteer from 7.0 to 10.0

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -221,7 +221,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/ci
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:
@@ -347,7 +347,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/happy
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:
@@ -457,7 +457,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/3rd-party-ci
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:
@@ -583,7 +583,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/3rd-party-happy
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
- Upgrade `syn-nodejs-puppeteer` version from 7.0 to 10.0 

Tested these changes when deploying a local stack to ensure the node version is at 20.x
<img width="1220" height="227" alt="Screenshot 2025-07-18 at 15 58 14" src="https://github.com/user-attachments/assets/87936b67-51ab-49c9-9a71-5522c20067da" />


### Why did it change

Need to upgrade this runtime so that the lambdas are running on node 20 because node 18 is reaching end of life. 

### Issue tracking

- [OJ-3289](https://govukverify.atlassian.net/browse/OJ-3289)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3289]: https://govukverify.atlassian.net/browse/OJ-3289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ