### PR TITLE
OJ-3289: fix - update version to 10.0 and removed escapeXpathString m…

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -221,7 +221,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/ci
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:
@@ -235,17 +235,17 @@ Resources:
           - |
             var synthetics = require('Synthetics');
             const log = require('SyntheticsLogger');
-            const escapeXpathString = (str) => {
-              return str.replace(/'/g, `', "'", '`);
-            };
+
             const clickByText = async (page, text) => {
-              const escapedText = escapeXpathString(text);
-              const linkHandlers = await page.$x("//a[contains(text(), '" + escapedText + "')]");
-              if (linkHandlers.length > 0) {
-                await linkHandlers[0].click();
-              } else {
-                throw new Error('Link not found:' + text);
+            const linkHandlers = await page.$$('a');
+              for (const linkHandler of linkHandlers) {
+              const linkHandlerText = await (await linkHandler.getProperty('textContent')).jsonValue();
+                if (linkHandlerText && linkHandlerText.trim().includes(text)) {
+                  await linkHandler.click();
+                  return;
+                }
               }
+            throw new Error('Link not found: ' + text);
             };
             const recordedScript = async function () {
               let page = await synthetics.getPage();
@@ -347,7 +347,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/happy
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:
@@ -361,17 +361,17 @@ Resources:
           - |
             var synthetics = require('Synthetics');
             const log = require('SyntheticsLogger');
-            const escapeXpathString = (str) => {
-              return str.replace(/'/g, `', "'", '`);
-            };
+
             const clickByText = async (page, text) => {
-              const escapedText = escapeXpathString(text);
-              const linkHandlers = await page.$x("//a[contains(text(), '" + escapedText + "')]");
-              if (linkHandlers.length > 0) {
-                await linkHandlers[0].click();
-              } else {
-                throw new Error('Link not found:' + text);
+            const linkHandlers = await page.$$('a');
+              for (const linkHandler of linkHandlers) {
+              const linkHandlerText = await (await linkHandler.getProperty('textContent')).jsonValue();
+                if (linkHandlerText && linkHandlerText.trim().includes(text)) {
+              await linkHandler.click();
+              return;
               }
+            }
+              throw new Error('Link not found: ' + text);
             };
             const recordedScript = async function () {
               let page = await synthetics.getPage();
@@ -457,7 +457,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/3rd-party-ci
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:
@@ -471,17 +471,17 @@ Resources:
           - |
             var synthetics = require('Synthetics');
             const log = require('SyntheticsLogger');
-            const escapeXpathString = (str) => {
-              return str.replace(/'/g, `', "'", '`);
-            };
+
             const clickByText = async (page, text) => {
-              const escapedText = escapeXpathString(text);
-              const linkHandlers = await page.$x("//a[contains(text(), '" + escapedText + "')]");
-              if (linkHandlers.length > 0) {
-                await linkHandlers[0].click();
-              } else {
-                throw new Error('Link not found:' + text);
+            const linkHandlers = await page.$$('a');
+              for (const linkHandler of linkHandlers) {
+              const linkHandlerText = await (await linkHandler.getProperty('textContent')).jsonValue();
+                if (linkHandlerText && linkHandlerText.trim().includes(text)) {
+                  await linkHandler.click();
+                  return;
+                }
               }
+            throw new Error('Link not found: ' + text);
             };
             const recordedScript = async function () {
               let page = await synthetics.getPage();
@@ -583,7 +583,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/3rd-party-happy
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-7.0
+      RuntimeVersion: syn-nodejs-puppeteer-10.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:
@@ -597,17 +597,17 @@ Resources:
           - |
             var synthetics = require('Synthetics');
             const log = require('SyntheticsLogger');
-            const escapeXpathString = (str) => {
-              return str.replace(/'/g, `', "'", '`);
-            };
+
             const clickByText = async (page, text) => {
-              const escapedText = escapeXpathString(text);
-              const linkHandlers = await page.$x("//a[contains(text(), '" + escapedText + "')]");
-              if (linkHandlers.length > 0) {
-                await linkHandlers[0].click();
-              } else {
-                throw new Error('Link not found:' + text);
+            const linkHandlers = await page.$$('a');
+              for (const linkHandler of linkHandlers) {
+              const linkHandlerText = await (await linkHandler.getProperty('textContent')).jsonValue();
+                if (linkHandlerText && linkHandlerText.trim().includes(text)) {
+                  await linkHandler.click();
+                  return;
+                }
               }
+            throw new Error('Link not found: ' + text);
             };
             const recordedScript = async function () {
               let page = await synthetics.getPage();


### PR DESCRIPTION
## Proposed changes

### What changed

- Due to the breaking change from puppeteer 22 which is in syn-nodejs-puppeteer-8.0 [here](https://github.com/puppeteer/puppeteer/pull/11782) meaning that `page.$x()` is no longer available. I removed the custoer handler and replaced it with a manual loop which incorporates text matching

Deployed my local stack `mariese-test-st` to ensure tests were passing with my changes:

<img width="1228" height="421" alt="Screenshot 2025-07-23 at 09 01 06" src="https://github.com/user-attachments/assets/d317f899-bf20-4c16-b4b4-b661426f5b14" />


### Why did it change

Node version out of date and breaking changes were introduced.

### Issue tracking

- [OJ-3289](https://govukverify.atlassian.net/browse/OJ-3289)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-3289]: https://govukverify.atlassian.net/browse/OJ-3289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ