### PR TITLE
feat: replaced sns alarm topc refs platform-alarm-warning-alert-topIC

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -38,6 +38,7 @@ Globals:
         NODE_OPTIONS: --enable-source-maps
 
 Resources:
+  # CloudWatch Alarms and Resources
   Nino3rdPartyHappyCanaryAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: DeployAlarms

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -54,9 +54,9 @@ Resources:
       Threshold: 75
       TreatMissingData: breaching
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue build-notifications-WarningAlertsTopicArn
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue build-notifications-WarningAlertsTopicArn
       Dimensions:
         - Name: CanaryName
           Value: !Ref Nino3rdPartyHappyCanary
@@ -77,9 +77,9 @@ Resources:
       Threshold: 75
       TreatMissingData: breaching
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue build-notifications-WarningAlertsTopicArn
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue build-notifications-WarningAlertsTopicArn
       Dimensions:
         - Name: CanaryName
           Value: !Ref NinoHappyCanary
@@ -100,9 +100,9 @@ Resources:
       Threshold: 75
       TreatMissingData: breaching
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue build-notifications-WarningAlertsTopicArn
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue build-notifications-WarningAlertsTopicArn
       Dimensions:
         - Name: CanaryName
           Value: !Ref NinoCICanary
@@ -123,9 +123,9 @@ Resources:
       Threshold: 75
       TreatMissingData: breaching
       OKActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue build-notifications-WarningAlertsTopicArn
       AlarmActions:
-        - !ImportValue platform-alarm-warning-alert-topic
+        - !ImportValue build-notifications-WarningAlertsTopicArn
       Dimensions:
         - Name: CanaryName
           Value: !Ref Nino3rdPartyCICanary


### PR DESCRIPTION

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

changed all references to SNS Alarms platform-alarm-warning-alert-topic topic arn to new build notification warning topic arn

### What changed

changed all references to SNS Alarms platform-alarm-warning-alert-topic topic arn to new build notification warning topic arn

### Why did it change

SNS alarms is being decommissioned

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-2206](https://govukverify.atlassian.net/browse/IPS-2206)


[IPS-2206]: https://govukverify.atlassian.net/browse/IPS-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ