### PR TITLE
OJ-3671: Bump canary runtime

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -709,7 +709,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/3rd-party-ci
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-10.0
+      RuntimeVersion: syn-nodejs-puppeteer-13.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:
@@ -829,7 +829,7 @@ Resources:
       StartCanaryAfterCreation: true
       ArtifactS3Location: !Sub s3://${CanariesBucket}/3rd-party-happy
       ExecutionRoleArn: !GetAtt CanariesRole.Arn
-      RuntimeVersion: syn-nodejs-puppeteer-10.0
+      RuntimeVersion: syn-nodejs-puppeteer-13.0
       Schedule:
         Expression: rate(15 minutes)
       Tags:


### PR DESCRIPTION
## Proposed changes

### What changed

Bumped canary runtime.

### Why did it change

2 of the 4 canaries were still using `RuntimeVersion: syn-nodejs-puppeteer-10.0`, which was creating lambdas using node20.

### Issue tracking

- [OJ-3671](https://govukverify.atlassian.net/browse/OJ-3671)


[OJ-3671]: https://govukverify.atlassian.net/browse/OJ-3671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ